### PR TITLE
feat(routing): restrict access to Identity account management pages

### DIFF
--- a/ExpressVoitures/Program.cs
+++ b/ExpressVoitures/Program.cs
@@ -56,6 +56,38 @@ using (var scope = app.Services.CreateScope())
 
 app.UseStaticFiles();
 
+app.MapGet("Identity/Account/Register", context =>
+{
+    context.Response.Redirect("/");
+    return Task.CompletedTask;
+});
+
+app.MapGet("Identity/Account/Manage", context =>
+{
+    context.Response.Redirect("/");
+    return Task.CompletedTask;
+});
+
+app.MapGet("Identity/Account/ForgotPassword", context =>
+{
+    context.Response.Redirect("/");
+    return Task.CompletedTask;
+});
+
+app.MapGet("Identity/Account/ResetPassword", context =>
+{
+    context.Response.Redirect("/");
+    return Task.CompletedTask;
+});
+
+app.MapGet("Identity/Account/ConfirmEmail", context =>
+{
+    context.Response.Redirect("/");
+    return Task.CompletedTask;
+});
+
+
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
this commit implements redirections for several Identity account management routes to enhance the security and user experience of the application. By redirecting requests for registration, account management, password reset, and email confirmation pages to the homepage, we ensure that unauthorized access to these functionalities is effectively blocked. This approach simplifies the user flow and maintains the focus on the core functionalities of the application.

Changes include:
- Redirecting "/Identity/Account/Register" to the homepage to disable direct access to the registration page.
- Redirecting "/Identity/Account/Manage" to prevent unauthorized account management.
- Redirecting "/Identity/Account/ForgotPassword" and "/Identity/Account/ResetPassword" to block direct access to password reset functionalities.
- Redirecting "/Identity/Account/ConfirmEmail" to avoid direct email confirmation attempts.

These modifications contribute to a more secure and streamlined user experience by limiting exposure to sensitive account management features.

Resolves issues:
- restrict creation of new user #98