### PR TITLE
feat: add properties for admin in Details view #108

### DIFF
--- a/ExpressVoitures/Controllers/CarsController.cs
+++ b/ExpressVoitures/Controllers/CarsController.cs
@@ -184,6 +184,7 @@ namespace ExpressVoitures.Controllers
         public async Task<IActionResult> Details(int id)
         {
             await _context.Car.FirstAsync(c => c.Id == id);
+            await _context.Car.Include(car => car.CarRepairs).FirstAsync(c => c.Id == id);
             CarViewModel carViewModel = _carService.GetCarViewModelById(id);
 
             return View(carViewModel);

--- a/ExpressVoitures/Views/Cars/Details.cshtml
+++ b/ExpressVoitures/Views/Cars/Details.cshtml
@@ -49,11 +49,31 @@
         <div class="col-md-3 car-info">
             <h3>@Model.CarBrand.CarBrandName - @Model.CarModel.CarModelName</h3>
             <ul class="list-unstyled">
-                <li> 
                 @if (User.Identity.IsAuthenticated && UserManager.GetUserAsync(User).Result != null)
                 {
-                    <strong>Code VIN :</strong> @Model.CodeVIN                }
-                </li>
+                    <li><strong>Code VIN :</strong> @Model.CodeVIN</li>
+                    <li><strong>Date d'achat :</strong> @Model.PurchaseDate?.ToString("dd/MM/yyyy")</li>
+                    <li><strong>Prix d'achat :</strong> @Model.PurchasePrice €</li>
+                    <li><strong>Date de vente :</strong> @Model.SaleDate?.ToString("dd/MM/yyyy")</li>
+                    @if (Model.CarRepairs != null && Model.CarRepairs.Count > 0)
+                    {
+                        <li>
+                            <strong>Réparations :</strong>
+                            <ul>
+                                @foreach (var repair in Model.CarRepairs)
+                                {
+                                    <li>@repair.RepairDescription : @repair.RepairCost €</li>
+                                }
+                            </ul>
+                        </li>
+                        <li>
+                            @{
+                                double total = ((double)Model.CarRepairs.Sum(repair => repair.RepairCost) + (double)Model.PurchasePrice);
+                            }
+                            <strong>Coût total (achat + réparations) :</strong> @total €
+                        </li>
+                    }
+                }
                 <li><strong>Finition :</strong> @Model.CarTrim.CarTrimName</li>
                 <li><strong>Motorisation :</strong> @(string.IsNullOrEmpty(Model.CarMotor?.CarMotorName) ? "Inconnu" : Model.CarMotor.CarMotorName)</li>
                 <li><strong>Kilométrage :</strong> @Model.Mileage km</li>
@@ -70,7 +90,10 @@
         <p>@Model.Description</p>
     </div>
 </div>
-<div id="sticky-banner">Une voiture vous intéresse ? Une question ? Contactez-nous...</div>
+@if (!User.Identity.IsAuthenticated && UserManager.GetUserAsync(User).Result == null)
+{
+    <div id="sticky-banner">Une voiture vous intéresse ? Une question ? Contactez-nous...</div>
+}
 
 <!-- Modal Lightbox -->
 <div id="myModal" class="modal">

--- a/ExpressVoitures/Views/Home/Index.cshtml
+++ b/ExpressVoitures/Views/Home/Index.cshtml
@@ -132,7 +132,10 @@
         }
     }
 </div>
-<div id="sticky-banner">Une voiture vous intéresse ? Une question ? Contactez-nous...</div>
+@if (!User.Identity.IsAuthenticated && UserManager.GetUserAsync(User).Result == null)
+{
+    <div id="sticky-banner">Une voiture vous intéresse ? Une question ? Contactez-nous...</div>
+}
 
 @section Scripts {
     @{


### PR DESCRIPTION
- introduce new fields in Details view for admin user only (purchase price, repairs details, purchase date)
- implement and display the total cost of the car

fix: the sticky banner is now only visible from a customer perspective (not displayed for an admin)

resolve issue: add properties for admin in Details view #108